### PR TITLE
Override param in register_rest_route

### DIFF
--- a/src/Router.php
+++ b/src/Router.php
@@ -157,7 +157,7 @@ class Router {
                     return $response;
                 }
             ];
-            register_rest_route( $this->_namespace, $route->get_path(), $args, true );
+            register_rest_route( $this->_namespace, $route->get_path(), $args );
         }
     }
 


### PR DESCRIPTION
Last param of [register_rest_route](https://developer.wordpress.org/reference/functions/register_rest_route/#parameters) function overrides existing routes, so in case when we set it to `true` its not possible to add different methods on the same route. So we can skip this param because it has value `false` by default.
